### PR TITLE
Debian fix init script so that it creates the /etc/ld.so.preload file if it does not exist.

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,11 @@
+imx-libc-neon (1.0.1-3) unstable; urgency=low
+
+  * Fix the init script so that it creates the ld.so.preload file
+    if it doesn't exist.
+   
+
+ -- William Schaub <william.schaub@genesi-usa.com>  Fri, 25 May 2012 23:54:04 -0400
+
 imx-libc-neon (1.0.1-2) unstable; urgency=low
 
   * Use patch from William Schaub, fix some bugs with adding multiple entries to

--- a/debian/imx-libc-neon.init
+++ b/debian/imx-libc-neon.init
@@ -27,6 +27,11 @@ DESC="libc-neon"
 #first check to see if the library is already inside of the preload file
 #then add it.
 add_preload(){
+    #the grep check below will fail if the ld.so.preload
+    #file does not exist first. 
+    if [ ! -f $ETC_LD_PRELOAD ]; then
+        touch $ETC_LD_PRELOAD
+    fi
     grep $LIBC_NEON $ETC_LD_PRELOAD >/dev/null
     if [ $? -eq 1 ]; then 
         echo $LIBC_NEON >>$ETC_LD_PRELOAD


### PR DESCRIPTION
I just found out while creating an image that the imx-libc-neon init script will do nothing at all if /etc/ld.so.preload does not exist. this pulll request will fix that problem and update the changelog to reflect that in the debian branch. 
